### PR TITLE
Feat: Add optional uv install step to Maven workflow (TT-2325)

### DIFF
--- a/.github/workflows/maven-verify-and-upload-artifact.yml
+++ b/.github/workflows/maven-verify-and-upload-artifact.yml
@@ -22,6 +22,10 @@ on:
       USE_GIT_LFS:
         required: false
         type: boolean
+      INSTALL_UV:
+        required: false
+        type: boolean
+        default: false
     secrets:
       VAULT_URL:
         required: true
@@ -77,6 +81,12 @@ jobs:
         with:
           java-version: ${{ inputs.JDK_VERSION  }}
           distribution: 'temurin'
+
+      - name: Install uv
+        # Needed by projects that bundle Python deps via uv (e.g. nifi-tekst-bundle).
+        # See: https://github.com/NationalLibraryOfNorway/nifi-tekst-bundle/pull/19
+        if: ${{ inputs.INSTALL_UV }}
+        uses: astral-sh/setup-uv@v6
 
       - name: Setup Maven and Cache
         uses: NationalLibraryOfNorway/tekst-workflows/.github/action/setup-maven@main


### PR DESCRIPTION
## Summary

- Adds an optional `INSTALL_UV` input (default `false`) to `maven-verify-and-upload-artifact.yml`
- When `true`, installs [uv](https://docs.astral.sh/uv/) via `astral-sh/setup-uv@v6` before the Maven build
- All existing callers are unaffected — the input defaults to `false`

## Cause

Required by `nifi-tekst-bundle` which bundles Python runtime deps into the NAR via `uv pip install` and runs pytest via `uv run pytest` as part of `mvn package`.

See: https://github.com/NationalLibraryOfNorway/nifi-tekst-bundle/pull/19

## Verification

- [ ] Existing Maven projects still build without changes (input defaults to false)
- [ ] `nifi-tekst-bundle` CI passes with `INSTALL_UV: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)