### PR TITLE
Feat: Add optional NODE_VERSION input to build workflows

### DIFF
--- a/.github/workflows/maven-build-and-deploy.yml
+++ b/.github/workflows/maven-build-and-deploy.yml
@@ -22,6 +22,10 @@ on:
       USE_HARBOR:
         required: true
         type: boolean
+      NODE_VERSION:
+        required: false
+        type: string
+        default: ''
     secrets:
       VAULT_URL:
         required: true
@@ -50,6 +54,7 @@ jobs:
       MAVEN_VERSION: ${{ inputs.MAVEN_VERSION }}
       USE_MAVEN_SETTINGS_FILE: ${{ inputs.USE_MAVEN_SETTINGS_FILE }}
       ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+      NODE_VERSION: ${{ inputs.NODE_VERSION }}
     secrets:
       VAULT_URL: ${{ secrets.VAULT_URL }}
       VAULT_SECRET_PATH: ${{ secrets.VAULT_SECRET_PATH }}

--- a/.github/workflows/maven-check.yml
+++ b/.github/workflows/maven-check.yml
@@ -9,6 +9,10 @@ on:
       MAVEN_VERSION:
         required: false
         type: string
+      NODE_VERSION:
+        required: false
+        type: string
+        default: ''
       USE_MAVEN_SETTINGS_FILE:
         required: true
         type: string
@@ -39,6 +43,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Node.js ${{ inputs.NODE_VERSION }}
+        if: ${{ inputs.NODE_VERSION != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
 
       - name: Set up JDK ${{ inputs.JDK_VERSION }}
         uses: actions/setup-java@v4

--- a/.github/workflows/maven-verify-and-upload-artifact.yml
+++ b/.github/workflows/maven-verify-and-upload-artifact.yml
@@ -22,6 +22,10 @@ on:
       USE_GIT_LFS:
         required: false
         type: boolean
+      NODE_VERSION:
+        required: false
+        type: string
+        default: ''
     secrets:
       VAULT_URL:
         required: true
@@ -72,6 +76,12 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
 
+      - name: Set up Node.js ${{ inputs.NODE_VERSION }}
+        if: ${{ inputs.NODE_VERSION != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.NODE_VERSION }}
+
       - name: Set up JDK ${{ inputs.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
@@ -87,14 +97,14 @@ jobs:
           s3_secret_key: ${{ secrets.S3_NB_SECRET_KEY }}
           s3_bucket: ${{ secrets.S3_NB_CACHE_BUCKET }}
 
-      - name: Check source code for existence of Hilla frontend
+      - name: Check source code for existence of frontend
         shell: bash
         run: |
           if [ -d "src/main/frontend" ]; then
-            echo "Hilla frontend found."
+            echo "Frontend found."
             echo "FRONTEND_EXISTS=true" >> $GITHUB_ENV
           else
-            echo "No Hilla frontend found."
+            echo "No frontend found."
             echo "FRONTEND_EXISTS=false" >> $GITHUB_ENV
           fi
 
@@ -123,14 +133,14 @@ jobs:
           sed -i "s/http_proxy_host/${{ steps.import-secrets.outputs.HTTP_PROXY_URL }}/g" .mvn/settings.xml
           sed -i "s/http_proxy_port/${{ steps.import-secrets.outputs.PROXY_PORT }}/g" .mvn/settings.xml
           if [ "${{ env.FRONTEND_EXISTS }}" == "true" ]; then
-            echo "Building with Hilla frontend using production profile"
+            echo "Building with frontend using production profile"
             mvn -e -s .mvn/settings.xml ${{ env.MAVEN_INFO }} verify -Pproduction
           elif [ "${{ inputs.UPLOAD_TO_ARTIFACTORY }}" == "true" ]; then
             sed -i "s/artifactory_user/${{ steps.import-secrets.outputs.ARTIFACTORY_USER }}/g" .mvn/settings.xml
             sed -i "s/artifactory_password/${{ steps.import-secrets.outputs.ARTIFACTORY_PASSWORD }}/g" .mvn/settings.xml
             mvn -e -s .mvn/settings.xml ${{ env.MAVEN_INFO }} verify
           else 
-            echo "No Artifactory upload or Hilla frontend found, skipping frontend build"
+            echo "No Artifactory upload or frontend found, skipping frontend build"
             mvn -e -s .mvn/settings.xml ${{ env.MAVEN_INFO }} verify
           fi
 
@@ -139,13 +149,13 @@ jobs:
         run: |
           echo "MAVEN_PROXY_SETTINGS=-Dhttp.proxyHost=${{ steps.import-secrets.outputs.HTTP_PROXY_URL }} -Dhttp.proxyPort=${{ steps.import-secrets.outputs.PROXY_PORT }} -Dhttps.proxyHost=${{ steps.import-secrets.outputs.HTTPS_PROXY_URL }} -Dhttps.proxyPort=${{ steps.import-secrets.outputs.PROXY_PORT }}" >> $GITHUB_ENV
           if [ "${{ env.FRONTEND_EXISTS }}" == "true" ]; then
-            echo "Building with Hilla frontend using production profile"
+            echo "Building with frontend using production profile"
             mvn -e ${{ env.MAVEN_INFO }} ${{ env.MAVEN_PROXY_SETTINGS }} verify -Pproduction
           elif [ "${{ inputs.UPLOAD_TO_ARTIFACTORY }}" == "true" ]; then
             echo "Uploading to Artifactory requires proxy settings, setting Artifactory credentials in settings.xml"
             exit 1
           else 
-            echo "No Artifactory upload or Hilla frontend found, skipping frontend build"
+            echo "No Artifactory upload or frontend found, skipping frontend build"
             mvn -e ${{ env.MAVEN_INFO }} ${{ env.MAVEN_PROXY_SETTINGS }} verify
           fi
 


### PR DESCRIPTION
## Summary

- Add optional `NODE_VERSION` input to `maven-check`, `maven-verify-and-upload-artifact`, and `maven-build-and-deploy` workflows
- When provided, a `setup-node` step runs before JDK setup to ensure the correct Node.js version is available
- Remove stale "Hilla frontend" references — replaced with generic "frontend"

## Why

Projects migrating from Vaadin Hilla to Spring WebFlux + Vite 7 require Node.js 20.19+ or 22.12+. The self-hosted CI runner ships Node.js 22.6.0 which is rejected by Vite 7. Passing `NODE_VERSION: '22'` installs a compatible Node.js via `setup-node@v4` before Maven runs the frontend build.

## Test plan

- [ ] Bikube `feat/hilla-to-webflux` branch references this branch (`@feat/optional-node-version-maven-check`) — PR CI run validates the `maven-check` workflow with `NODE_VERSION: '22'`
- [ ] Stage/prod build workflows validated once this merges to main and bikube switches back to `@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)