### PR TITLE
Fix: Make Docker image push resilient to Harbor blob-upload session errors

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver: docker
+          driver: docker-container
 
       - name: Import harbor secrets from Vault
         id: import-secrets
@@ -104,11 +104,15 @@ jobs:
         run: ls -la
 
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: Wandalen/wretry.action@v3
         with:
-          push: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            ENVIRONMENT=${{ inputs.ENVIRONMENT }}
+          action: docker/build-push-action@v7
+          attempt_limit: 3
+          attempt_delay: 15000
+          with: |
+            push: true
+            context: .
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            build-args: |
+              ENVIRONMENT=${{ inputs.ENVIRONMENT }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -103,16 +103,51 @@ jobs:
       - name: Sanity LS
         run: ls -la
 
-      - name: Build image
-        uses: Wandalen/wretry.action@v3
+      # Harbor intermittently drops the blob upload session mid-push ("blob upload
+      # unknown to registry"), unrelated to what's being built. Retry natively by
+      # chaining the same action with continue-on-error + outcome checks, instead
+      # of pulling in a third-party retry-wrapper action.
+      - name: Build and push image (attempt 1)
+        id: build-1
+        continue-on-error: true
+        uses: docker/build-push-action@v7
         with:
-          action: docker/build-push-action@v7
-          attempt_limit: 3
-          attempt_delay: 15000
-          with: |
-            push: true
-            context: .
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
-            build-args: |
-              ENVIRONMENT=${{ inputs.ENVIRONMENT }}
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVIRONMENT=${{ inputs.ENVIRONMENT }}
+
+      - name: Wait before retry (attempt 2)
+        if: steps.build-1.outcome == 'failure'
+        run: sleep 15
+
+      - name: Build and push image (attempt 2)
+        id: build-2
+        if: steps.build-1.outcome == 'failure'
+        continue-on-error: true
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVIRONMENT=${{ inputs.ENVIRONMENT }}
+
+      - name: Wait before retry (attempt 3)
+        if: steps.build-1.outcome == 'failure' && steps.build-2.outcome == 'failure'
+        run: sleep 15
+
+      - name: Build and push image (attempt 3)
+        id: build-3
+        if: steps.build-1.outcome == 'failure' && steps.build-2.outcome == 'failure'
+        uses: docker/build-push-action@v7
+        with:
+          push: true
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVIRONMENT=${{ inputs.ENVIRONMENT }}


### PR DESCRIPTION
## Summary

Consuming repos (e.g. bikube) have been intermittently hitting `buildx failed with: ERROR: failed to solve: failed to push .../<repo>:main: unknown: blob upload unknown to registry` on the Docker push step. Traced this back through bikube's Actions history and found the exact same failure going back to at least 2026-03-26 - across many different commits/PRs, with no common thread other than "pushing to Harbor". That rules out anything build-specific; it's a registry-side upload-session issue, likely made worse by the buildx driver in use.

## Changes

- **`docker/setup-buildx-action`: `driver: docker` -> `driver: docker-container`.** The plain `docker` driver runs BuildKit embedded in the Docker daemon; Docker's own docs recommend `docker-container` (BuildKit in its own container) for anything beyond local dev, and it's a commonly reported fix for this exact "blob upload unknown" symptom. No step in this job needs the built image loaded into the local daemon afterward, so there's no behavioural downside.
- **Retry the push natively, still using the official action.** `docker/build-push-action` has no built-in retry (open feature request, unimplemented), and there's no first-party GitHub retry primitive either. Rather than pull in a third-party wrapper action, the same `docker/build-push-action` step is repeated up to 3 times, gated by `continue-on-error` + `steps.<id>.outcome == 'failure'` checks, with a 15s sleep between attempts. No added action dependency; the trade-off is the `with:` block is duplicated per attempt.
- **Bump `docker/build-push-action` v5 -> v7** while touching this step (two majors behind). Confirmed the inputs we use (`push`, `context`, `tags`, `labels`, `build-args`) are unchanged in v7's action.yml.

## Test plan

- [x] Validated the resulting YAML parses correctly and the retry step graph (if/continue-on-error/outcome) evaluates as intended
- [x] Confirmed `push`/`context`/`tags`/`labels`/`build-args` inputs still exist unchanged in `docker/build-push-action@v7`'s action.yml
- [ ] Since this is a reusable workflow, the real test is the next consuming-repo pipeline run once merged - recommend watching bikube's next push-to-main build

🤖 Generated with [Claude Code](https://claude.com/claude-code)