### PR TITLE
Fix: Pass daemon proxy config into docker-container buildx driver (TT-2443)

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -33,10 +33,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Read proxy config from Docker daemon
+        run: |
+          echo "DOCKER_HTTP_PROXY=$(docker info --format '{{ .HTTPProxy }}')" >> "$GITHUB_ENV"
+          echo "DOCKER_HTTPS_PROXY=$(docker info --format '{{ .HTTPSProxy }}')" >> "$GITHUB_ENV"
+          echo "DOCKER_NO_PROXY=$(docker info --format '{{ .NoProxy }}')" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
+          driver-opts: |
+            network=host
+            env.http_proxy=${{ env.DOCKER_HTTP_PROXY }}
+            env.https_proxy=${{ env.DOCKER_HTTPS_PROXY }}
+            env.no_proxy=${{ env.DOCKER_NO_PROXY }}
 
       - name: Import harbor secrets from Vault
         id: import-secrets


### PR DESCRIPTION
## Summary
- #22 switched the buildx driver from `docker` (BuildKit embedded in the Docker daemon) to `docker-container` (BuildKit in its own container), to fix intermittent Harbor blob-upload session errors.
- `docker-container` builds run in an isolated container that does **not** inherit the daemon's proxy config, unlike the old `docker` driver. Registries outside `No Proxy` (Docker Hub) are now reached via a direct, unproxied connection that the firewall silently drops.
- Confirmed in dimo-harvester's stage pipeline: every push to Docker Hub since 2026-07-10 has timed out (`dial tcp ...:443: i/o timeout` against `registry-1.docker.io`), and the job log shows `docker/build-push-action` logging "No proxy configuration found" right before the failing build/push step. Harbor pushes are unaffected since `*.nb.no` is already in `No Proxy` and was always reached directly.
- Since this workflow is referenced via floating `@main`, every consuming project with `USE_HARBOR: false` has been exposed since the driver switch, regardless of any change in the consuming repo.

Fix: read the daemon's own proxy settings via `docker info` and pass them into the `docker-container` driver explicitly via `driver-opts`, so BuildKit's isolated container proxies external registry traffic the same way the daemon does.

Fixes TT-2443.

## Test plan
- [ ] Trigger dimo-harvester's stage pipeline (`USE_HARBOR: false`) against this branch/commit and confirm the Docker Hub push succeeds
- [ ] Confirm a Harbor push (`USE_HARBOR: true`) still succeeds unaffected