### PR TITLE
Fix: Quote no_proxy driver-opt to protect embedded commas (TT-2443)

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
             network=host
             env.http_proxy=${{ env.DOCKER_HTTP_PROXY }}
             env.https_proxy=${{ env.DOCKER_HTTPS_PROXY }}
-            env.no_proxy=${{ env.DOCKER_NO_PROXY }}
+            env.no_proxy="${{ env.DOCKER_NO_PROXY }}"
 
       - name: Import harbor secrets from Vault
         id: import-secrets


### PR DESCRIPTION
## Summary
- Follow-up to #29. Testing against dimo-harvester's stage pipeline surfaced a new failure at builder creation: `ERROR: invalid value "127.0.0.1", expecting k=v`.
- `--driver-opt` values are parsed as comma-delimited `key=value` pairs, so the unquoted `no_proxy` list (`localhost,127.0.0.1,10.233.0.0/18,10.233.64.0/18,*.nb.no`) was being split apart mid-value — everything after the first comma was treated as separate, invalid driver-opt entries.
- Quote the `no_proxy` value so buildx's CSV-style parser treats the embedded commas as literal.

Fixes TT-2443.

## Test plan
- [ ] Trigger dimo-harvester's stage pipeline (`USE_HARBOR: false`) and confirm `docker buildx create` succeeds and the Docker Hub push completes