### PR TITLE
Fix: Quote whole no_proxy field, not just the value (TT-2443)

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
             network=host
             env.http_proxy=${{ env.DOCKER_HTTP_PROXY }}
             env.https_proxy=${{ env.DOCKER_HTTPS_PROXY }}
-            env.no_proxy="${{ env.DOCKER_NO_PROXY }}"
+            "env.no_proxy=${{ env.DOCKER_NO_PROXY }}"
 
       - name: Import harbor secrets from Vault
         id: import-secrets


### PR DESCRIPTION
## Summary
- Follow-up to #29 and #30. #30 quoted only the value (`env.no_proxy="localhost,..."`), which still failed: `ERROR: parse error on line 1, column 14: bare " in non-quoted-field`.
- buildx's driver-opt parser is a CSV-style reader that only honors a quote as opening a quoted field if it's the very first character of that field. Since our field starts with `env.no_proxy=`, a quote appearing after that prefix is a bare quote mid-field, not a valid opener.
- Quote the entire `key=value` pair instead: `"env.no_proxy=${{ env.DOCKER_NO_PROXY }}"`.

Fixes TT-2443.

## Test plan
- [ ] Trigger dimo-harvester's stage pipeline (`USE_HARBOR: false`) and confirm `docker buildx create` succeeds and the Docker Hub push completes